### PR TITLE
Add styled homepage and placeholder pages

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,11 @@
+import Link from "next/link";
+
+export default function AboutPage() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center gap-4 p-8">
+      <h1 className="text-3xl font-bold">About</h1>
+      <p className="text-center max-w-md">Learn more about the Artist Manager platform.</p>
+      <Link href="/" className="text-blue-600 hover:underline">Back to Home</Link>
+    </div>
+  );
+}

--- a/src/app/artists/page.tsx
+++ b/src/app/artists/page.tsx
@@ -1,0 +1,11 @@
+import Link from "next/link";
+
+export default function ArtistsPage() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center gap-4 p-8">
+      <h1 className="text-3xl font-bold">Artists</h1>
+      <p className="text-center max-w-md">This is a placeholder page for artist listings.</p>
+      <Link href="/" className="text-blue-600 hover:underline">Back to Home</Link>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,48 @@
-import Image from "next/image";
+import Link from "next/link";
 
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+    <div className="flex flex-col min-h-screen font-[family-name:var(--font-geist-sans)]">
+      <header className="py-4 px-8 flex justify-between items-center border-b">
+        <h1 className="text-xl font-bold">Artist Manager</h1>
+        <nav className="flex gap-4 text-sm">
+          <Link href="/" className="hover:underline">Home</Link>
+          <Link href="/artists" className="hover:underline">Artists</Link>
+          <Link href="/about" className="hover:underline">About</Link>
+        </nav>
+      </header>
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
+      <main className="flex-grow">
+        <section className="text-center py-16 px-8">
+          <h2 className="text-4xl font-bold mb-4">Discover and book amazing talent</h2>
+          <p className="max-w-xl mx-auto mb-6">
+            Manage your favorite performers and connect with artists for your next event.
+          </p>
+          <Link
+            href="/artists"
+            className="inline-block bg-blue-600 text-white px-6 py-3 rounded-md hover:bg-blue-700"
           >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
+            Explore Artists
+          </Link>
+        </section>
+
+        <section className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6 px-8 pb-16">
+          {[
+            { title: "Singers", desc: "Find vocal talents for any genre." },
+            { title: "Dancers", desc: "Energetic performers for your stage." },
+            { title: "Speakers", desc: "Engaging voices for conferences." },
+            { title: "DJs", desc: "Keep the party going all night." },
+          ].map((c) => (
+            <div
+              key={c.title}
+              className="border rounded-lg p-6 shadow-sm flex flex-col items-start"
+            >
+              <h3 className="text-lg font-semibold mb-2">{c.title}</h3>
+              <p className="text-sm text-gray-600 dark:text-gray-300">{c.desc}</p>
+            </div>
+          ))}
+        </section>
       </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- create simple About and Artists pages for navigation
- replace starter homepage with header, hero, CTA, and category cards

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_685ad6e3db40832592a43b61839c6f25