### PR TITLE
Add artist listing page with filters

### DIFF
--- a/src/app/api/artists/route.ts
+++ b/src/app/api/artists/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from "next/server";
+import artists from "@/data/artists.json";
+
+export async function GET() {
+  return NextResponse.json(artists);
+}

--- a/src/app/artists/page.tsx
+++ b/src/app/artists/page.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import artistsData from '@/data/artists.json';
+import ArtistCard, { Artist } from '@/components/ArtistCard';
+import FilterBlock, { Filters } from '@/components/FilterBlock';
+
+export default function ArtistsPage() {
+  const [filters, setFilters] = useState<Filters>({
+    category: '',
+    location: '',
+    priceRange: '',
+  });
+
+  const filteredArtists = useMemo(() => {
+    return (artistsData as Artist[]).filter((artist) => {
+      return (
+        (!filters.category || artist.category === filters.category) &&
+        (!filters.location || artist.location === filters.location) &&
+        (!filters.priceRange || artist.priceRange === filters.priceRange)
+      );
+    });
+  }, [filters]);
+
+  return (
+    <div className="p-4 md:p-8 flex flex-col gap-4">
+      <FilterBlock artists={artistsData as Artist[]} filters={filters} onChange={setFilters} />
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {filteredArtists.map((artist) => (
+          <ArtistCard key={artist.id} artist={artist} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ArtistCard.tsx
+++ b/src/components/ArtistCard.tsx
@@ -1,0 +1,21 @@
+export type Artist = {
+  id: number;
+  name: string;
+  category: string;
+  priceRange: string;
+  location: string;
+};
+
+export default function ArtistCard({ artist }: { artist: Artist }) {
+  return (
+    <div className="border rounded p-4 flex flex-col gap-1">
+      <h3 className="text-lg font-semibold">{artist.name}</h3>
+      <p className="text-sm text-gray-600">{artist.category}</p>
+      <p className="text-sm">{artist.priceRange}</p>
+      <p className="text-sm">{artist.location}</p>
+      <button className="mt-2 px-3 py-1 bg-blue-600 text-white rounded text-sm">
+        Ask for Quote
+      </button>
+    </div>
+  );
+}

--- a/src/components/FilterBlock.tsx
+++ b/src/components/FilterBlock.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { Artist } from './ArtistCard';
+
+export type Filters = {
+  category: string;
+  location: string;
+  priceRange: string;
+};
+
+type Props = {
+  artists: Artist[];
+  filters: Filters;
+  onChange: (filters: Filters) => void;
+};
+
+export default function FilterBlock({ artists, filters, onChange }: Props) {
+  const categories = Array.from(new Set(artists.map(a => a.category)));
+  const locations = Array.from(new Set(artists.map(a => a.location)));
+  const priceRanges = Array.from(new Set(artists.map(a => a.priceRange)));
+
+  function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const { name, value } = e.target;
+    onChange({ ...filters, [name]: value });
+  }
+
+  return (
+    <div className="flex flex-col sm:flex-row gap-4">
+      <select
+        name="category"
+        value={filters.category}
+        onChange={handleChange}
+        className="border p-2 rounded"
+      >
+        <option value="">All Categories</option>
+        {categories.map(cat => (
+          <option key={cat} value={cat}>
+            {cat}
+          </option>
+        ))}
+      </select>
+
+      <select
+        name="location"
+        value={filters.location}
+        onChange={handleChange}
+        className="border p-2 rounded"
+      >
+        <option value="">All Locations</option>
+        {locations.map(loc => (
+          <option key={loc} value={loc}>
+            {loc}
+          </option>
+        ))}
+      </select>
+
+      <select
+        name="priceRange"
+        value={filters.priceRange}
+        onChange={handleChange}
+        className="border p-2 rounded"
+      >
+        <option value="">All Price Ranges</option>
+        {priceRanges.map(range => (
+          <option key={range} value={range}>
+            {range}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/data/artists.json
+++ b/src/data/artists.json
@@ -1,0 +1,7 @@
+[
+  {"id":1,"name":"Alice Painter","category":"Painter","priceRange":"$500-$1000","location":"New York"},
+  {"id":2,"name":"Bob Musician","category":"Musician","priceRange":"$1000-$2000","location":"Los Angeles"},
+  {"id":3,"name":"Carla Dancer","category":"Dancer","priceRange":"$300-$700","location":"Chicago"},
+  {"id":4,"name":"Dave Painter","category":"Painter","priceRange":"$700-$1500","location":"San Francisco"},
+  {"id":5,"name":"Eve Musician","category":"Musician","priceRange":"$2000-$4000","location":"New York"}
+]


### PR DESCRIPTION
## Summary
- create API route to serve artists from JSON
- add artist listing page with filtering
- implement `ArtistCard` and `FilterBlock` components
- provide sample artist data

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685adf0dc1808325b8f5b2e92f11d794